### PR TITLE
Move taps and sqlite gems to development group.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ gem 'hoptoad_notifier', '2.4.11'
 
 group :development do
   gem 'heroku'
+  gem 'sqlite3-ruby', '1.2.5'
+  gem 'taps'
 end
-gem 'sqlite3-ruby', '1.2.5'
-gem 'taps'
 
 group :production do
   gem 'pg'


### PR DESCRIPTION
`sqlite` not being scoped to development is causing an error when I push to Heroku.
